### PR TITLE
Add support for MCL2, fix incompatibility with Airtank

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,7 @@
 default?
+mcl_core?
+mcl_sounds?
+airtanks?
 moretrees?
 intllib?
 doc?

--- a/init.lua
+++ b/init.lua
@@ -2,6 +2,16 @@
 local MP = minetest.get_modpath(minetest.get_current_modname())
 local S, NS = dofile(MP.."/intllib.lua")
 
+-- MCL2 compatibility
+moditems = {}
+
+if core.get_modpath("mcl_core") and mcl_core then -- means MineClone 2 is loaded, this is its core mod
+	moditems.IRON_ITEM = "mcl_core:iron_ingot"  -- MCL iron
+else         -- fallback, assume default (MineTest Game) is loaded, otherwise it will error anyway here.
+	moditems.IRON_ITEM = "default:steel_ingot"  -- MCL iron
+end
+
+
 local pontoons_override_logs = minetest.settings:get_bool("pontoons_override_logs") -- default false
 
 local pontoons_override_wood = minetest.settings:get_bool("pontoons_override_wood") -- default false
@@ -31,7 +41,11 @@ if pontoons_wood_pontoons then
 	local default_sound
 	local wood_burn_time
 	if default_modpath then
-		default_sound = default.node_sound_wood_defaults()
+		if mcl_sounds then
+			default_sound = mcl_sounds.node_sound_wood_defaults()
+		else
+			default_sound = default.node_sound_wood_defaults()
+		end
 		wood_burn_time = minetest.get_craft_result({method="fuel", width=1, items={ItemStack("group:wood")}}).time
 	end
 	if not wood_burn_time then wood_burn_time = 7 end
@@ -47,7 +61,19 @@ if pontoons_wood_pontoons then
 		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, wood = 1},
 		sounds = default_sound,
 	})
-	
+
+-- modify recipe, if "airtank" mod is loaded as it has similar recipe and conflicts with pontoons.
+
+if core.get_modpath("airtanks") and airtanks then
+	minetest.register_craft({
+		output = 'pontoons:wood_pontoon 4',
+		recipe = {
+			{"group:wood","group:wood","group:wood"},
+			{"","",""},
+			{"","","group:wood"},
+		}
+	})
+else
 	minetest.register_craft({
 		output = 'pontoons:wood_pontoon 4',
 		recipe = {
@@ -56,7 +82,8 @@ if pontoons_wood_pontoons then
 			{"","group:wood",""},
 		}
 	})
-	
+end
+
 	minetest.register_craft({
 		type = "fuel",
 		recipe = "pontoons:wood_pontoon",
@@ -68,10 +95,14 @@ end
 if pontoons_steel_pontoons then
 	local default_sound
 	if default_modpath then
-		if 	default.node_sound_metal_defaults ~= nil then
-			default_sound = default.node_sound_metal_defaults()
+		if mcl_sounds then
+			default_sound = mcl_sounds.node_sound_metal_defaults()
 		else
-			default_sound = default.node_sound_wood_defaults()
+			if default.node_sound_metal_defaults then
+				default_sound = default.node_sound_metal_defaults()
+			else
+				default_sound = default.node_sound_wood_defaults()
+			end
 		end
 	end
 	
@@ -87,13 +118,24 @@ if pontoons_steel_pontoons then
 	})
 	
 	if default_modpath then
-		minetest.register_craft({
-			output = 'pontoons:steel_pontoon',
-			recipe = {
-				{"","default:steel_ingot",""},
-				{"default:steel_ingot","","default:steel_ingot"},
-				{"","default:steel_ingot",""},
-			}
-		})
+		if core.get_modpath("airtanks") and airtanks then
+			minetest.register_craft({
+				output = 'pontoons:steel_pontoon',
+				recipe = {
+					{"",moditems.IRON_ITEM,""},
+					{moditems.IRON_ITEM,"",moditems.IRON_ITEM},
+					{"","",moditems.IRON_ITEM},
+				}
+			})
+	  else		
+			minetest.register_craft({
+				output = 'pontoons:steel_pontoon',
+				recipe = {
+					{"",moditems.IRON_ITEM,""},
+					{moditems.IRON_ITEM,"",moditems.IRON_ITEM},
+					{"",moditems.IRON_ITEM,""},
+				}
+			})
+		end
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -3,7 +3,7 @@ local MP = minetest.get_modpath(minetest.get_current_modname())
 local S, NS = dofile(MP.."/intllib.lua")
 
 -- MCL2 compatibility
-moditems = {}
+local moditems = {}
 
 if core.get_modpath("mcl_core") and mcl_core then -- means MineClone 2 is loaded, this is its core mod
 	moditems.IRON_ITEM = "mcl_core:iron_ingot"  -- MCL iron


### PR DESCRIPTION
this pq 
- enhances the mod with compatibility to favorite MineClone2 game.
- also solves the conflict with "Airtank" mod which uses same recipe placement, by detecting and using an alternate recipe.